### PR TITLE
Use Google Custom search

### DIFF
--- a/src/predict_industry.ts
+++ b/src/predict_industry.ts
@@ -5,7 +5,7 @@ import { initializeAgentExecutorWithOptions } from "langchain/agents";
 import { OpenAI } from "langchain/llms/openai";
 import { StructuredOutputParser } from "langchain/output_parsers";
 import { PromptTemplate } from "langchain/prompts";
-import { SerpAPI } from "langchain/tools";
+import { GoogleCustomSearch } from "langchain/tools";
 
 const parser = StructuredOutputParser.fromNamesAndDescriptions({
   name: "Company name",
@@ -21,9 +21,9 @@ const prompt = new PromptTemplate({
 
 const model = new OpenAI({ temperature: 0 });
 const tools = [
-  new SerpAPI(process.env.SERPAPI_API_KEY, {
-    hl: "en",
-    gl: "us",
+  new GoogleCustomSearch({
+    googleCSEId: process.env.GOOGLE_CSE_ID,
+    apiKey: process.env.GOOGLE_API_KEY,
   }),
 ];
 


### PR DESCRIPTION
- Google custom search is cheaper (100 requests/ day for free)
- Look for `LLM test key` in One Password for keys

<img width="822" alt="image" src="https://github.com/knot-inc/llm-experiments/assets/6277118/af0ca3a6-a919-4810-ba22-bb9356c19814">


<!-- start pr-codex -->

---

## PR-Codex overview
This PR replaces the `SerpAPI` tool with `GoogleCustomSearch` in the `predict_industry.ts` file.

### Detailed summary
- Replaced `SerpAPI` import with `GoogleCustomSearch` import.
- Updated the `tools` array to use `GoogleCustomSearch` instead of `SerpAPI`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->