### PR TITLE
parse resume and insert to airtable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-error.log*
 
 src/test/cover_letter_**.txt
 src/test/**_vector_store
+resume/
+out/

--- a/src/resume_parser/index.ts
+++ b/src/resume_parser/index.ts
@@ -1,0 +1,99 @@
+import fs from "fs";
+import path, { dirname } from "path";
+import dotenv from "dotenv";
+import { parseResume } from "./parse_resume.js";
+import { fileURLToPath } from "url";
+import { Resume } from "./resumeType.js";
+
+dotenv.config();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const main = async () => {
+  // load resumes from `resume` folder and parse them
+  const resumesDir = path.join(`${__dirname}/../../resume`);
+  const resumes = fs.readdirSync(resumesDir);
+  const parsedResumes: { filename: string; resume: Resume }[] = [];
+  for (const resume of resumes) {
+    if (resume.endsWith(".pdf")) {
+      console.log(`Parsing ${resume}`);
+      parsedResumes.push({
+        filename: resume,
+        resume: await parseResume(path.join(resumesDir, resume)),
+      });
+    }
+  }
+
+  // const resumesDir = path.join(`${__dirname}/../../out`);
+  // const resumes = fs.readdirSync(resumesDir);
+  // const parsedResumes: ResumeData[] = [];
+  // for (const resume of resumes) {
+  //   if (resume.endsWith(".json")) {
+  //     console.log(`Parsing ${resume}`);
+  //     parsedResumes.push(fs.readFileSync(path.join(resumesDir, resume))));
+  //   }
+  // }
+  // put it in to a csv format
+  const v = [];
+  for (const parseRes of parsedResumes) {
+    if (
+      parseRes.resume.ParsingResponse.Code !== "Success" &&
+      !parseRes.resume.ResumeData
+    ) {
+      console.log(
+        `Failed to parse resume ${parseRes.filename}:`,
+        parseRes.resume.ParsingResponse.Message,
+      );
+      continue;
+    }
+    const resume = parseRes.resume.ResumeData;
+    const email = resume.ContactInformation.EmailAddresses[0];
+    const github = resume.ContactInformation.WebAddresses?.find(
+      (x) => x.Type === "GitHub",
+    )?.Address;
+    const linkedin = resume.ContactInformation.WebAddresses?.find(
+      (x) => x.Type === "LinkedIn",
+    )?.Address;
+    const portfolio = resume.ContactInformation.WebAddresses?.find(
+      (x) => x.Type === "PersonalWebsite",
+    )?.Address;
+    const totalWorkExperience =
+      resume.EmploymentHistory.ExperienceSummary.MonthsOfWorkExperience;
+    const workExperiences = resume.EmploymentHistory.Positions?.map((p) => {
+      return {
+        id: p.Id,
+        startDate: p.StartDate?.Date || "unknown",
+        endDate: p.EndDate?.Date || "unknown",
+        title: p.JobTitle?.Normalized || "unknown",
+        company: p.Employer?.Name?.Normalized || "unknown",
+        description: p.Description?.replaceAll("\n", " ") || "unknown",
+      };
+    });
+    const skills = resume.Skills.Normalized?.filter((s) =>
+      s.FoundIn.some((skill) => skill.SectionType === "SKILLS"),
+    ).map((s) => {
+      return s.Name;
+    });
+    v.push({
+      email,
+      github,
+      linkedin,
+      portfolio,
+      totalWorkExperience,
+      workExperiences,
+      skills,
+    });
+  }
+
+  // write it to a file
+  const outDir = path.join(`${__dirname}/../../out/`);
+  if (fs.existsSync(outDir) === false) {
+    fs.mkdirSync(outDir);
+  }
+  fs.writeFileSync(path.join(outDir, "parsed_resumes.json"), JSON.stringify(v));
+};
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/resume_parser/parse_resume.ts
+++ b/src/resume_parser/parse_resume.ts
@@ -1,0 +1,53 @@
+import fs from "fs";
+import path, { dirname } from "path";
+import dotenv from "dotenv";
+import { Resume } from "./resumeType.js";
+import { fileURLToPath } from "url";
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const options = (postData: string) => ({
+  method: "POST",
+  headers: {
+    "Sovren-AccountId": `${process.env.SOVREN_ACCOUNT_ID}`,
+    "Sovren-ServiceKey": `${process.env.SOVREN_KEY}`,
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  },
+  body: postData,
+});
+
+export const parseResume = async (filepath: string): Promise<Resume> => {
+  const base64Doc = fs.readFileSync(filepath).toString("base64");
+  const modifiedDate: string = new Date(fs.statSync(filepath).mtimeMs)
+    .toISOString()
+    .substring(0, 10);
+  // other options here (see https://sovren.com/technical-specs/latest/rest-api/resume-parser/api/)
+  const postData: string = JSON.stringify({
+    DocumentAsBase64String: base64Doc,
+    DocumentLastModified: modifiedDate,
+    SkillsSettings: {
+      Normalize: true,
+    },
+  });
+  const response = await fetch(
+    "https://rest.resumeparsing.com/v10/parser/resume",
+    options(postData),
+  );
+  const data = await response.json();
+  const resume = data.Value as Resume;
+  //console.log(JSON.stringify(resume));
+
+  // Write result to file
+  const outDir = path.join(`${__dirname}/../../out/`);
+  if (fs.existsSync(outDir) === false) {
+    fs.mkdirSync(outDir);
+  }
+  const fileName = path.basename(filepath).replace(".pdf", ".json");
+
+  fs.writeFileSync(path.join(outDir, fileName), JSON.stringify(resume));
+  return resume;
+};

--- a/src/resume_parser/resumeType.ts
+++ b/src/resume_parser/resumeType.ts
@@ -1,0 +1,276 @@
+export interface Resume {
+  ParsingResponse: ParsingResponse;
+  ResumeData: ResumeData;
+  RedactedResumeData: RedactedResumeData;
+  ConversionMetadata: ConversionMetadata;
+  ParsingMetadata: ParsingMetadata;
+}
+export interface ParsingResponse {
+  Code: string;
+  Message: string;
+}
+export interface ResumeData {
+  ContactInformation: ContactInformation;
+  ProfessionalSummary: string;
+  Education: Education;
+  EmploymentHistory: EmploymentHistory;
+  Skills: Skills;
+  Certifications?: CertificationsEntity[] | null;
+  LanguageCompetencies?: LanguageCompetenciesEntity[] | null;
+  References?: ReferencesEntity[] | null;
+  QualificationsSummary: string;
+  ResumeMetadata: ResumeMetadata;
+}
+export interface ContactInformation {
+  CandidateName: CandidateName;
+  Telephones?: TelephonesEntity[] | null;
+  EmailAddresses?: string[] | null;
+  WebAddresses?: WebAddressesEntity[] | null;
+}
+export interface CandidateName {
+  FormattedName: string;
+  GivenName: string;
+  FamilyName: string;
+}
+export interface TelephonesEntity {
+  Raw: string;
+  Normalized: string;
+  InternationalCountryCode: string;
+  SubscriberNumber: string;
+}
+export interface WebAddressesEntity {
+  Address: string;
+  Type: string;
+}
+export interface Education {
+  EducationDetails?: EducationDetailsEntity[] | null;
+}
+export interface EducationDetailsEntity {
+  Id: string;
+  Text: string;
+  SchoolName: SchoolNameOrTelephonesEntity;
+  SchoolType: string;
+  LastEducationDate: LastEducationDateOrStartDateOrEndDate;
+  StartDate: LastEducationDateOrStartDateOrEndDate;
+  EndDate: LastEducationDateOrStartDateOrEndDate;
+  Majors?: string[] | null;
+  GPA?: GPA | null;
+}
+export interface SchoolNameOrTelephonesEntity {
+  Raw: string;
+  Normalized: string;
+}
+export interface LastEducationDateOrStartDateOrEndDate {
+  Date: string;
+  IsCurrentDate: boolean;
+  FoundYear: boolean;
+  FoundMonth: boolean;
+  FoundDay: boolean;
+}
+export interface GPA {
+  Score: string;
+  ScoringSystem: string;
+  MaxScore: string;
+  MinimumScore: string;
+  NormalizedScore: number;
+}
+export interface EmploymentHistory {
+  ExperienceSummary: ExperienceSummary;
+  Positions?: PositionsEntity[] | null;
+}
+export interface ExperienceSummary {
+  Description: string;
+  MonthsOfWorkExperience: number;
+  MonthsOfManagementExperience: number;
+  ExecutiveType: string;
+  AverageMonthsPerEmployer: number;
+  FulltimeDirectHirePredictiveIndex: number;
+  ManagementStory: string;
+  CurrentManagementLevel: string;
+  ManagementScore: number;
+}
+export interface PositionsEntity {
+  Id: string;
+  Employer: Employer;
+  RelatedToByCompanyName?: string[] | null;
+  IsSelfEmployed: boolean;
+  IsCurrent: boolean;
+  JobTitle: JobTitle;
+  StartDate: LastEducationDateOrStartDateOrEndDate;
+  EndDate: LastEducationDateOrStartDateOrEndDate;
+  JobType: string;
+  JobLevel: string;
+  TaxonomyPercentage: number;
+  Description: string;
+}
+export interface Employer {
+  Name: NameOrJobTitle;
+}
+export interface NameOrJobTitle {
+  Probability: string;
+  Raw: string;
+  Normalized: string;
+}
+export interface JobTitle {
+  Raw: string;
+  Normalized: string;
+  Probability: string;
+  Variations?: string[] | null;
+}
+export interface Skills {
+  Raw?: RawEntity[] | null;
+  Normalized?: NormalizedEntity[] | null;
+  RelatedProfessionClasses?: RelatedProfessionClassesEntity[] | null;
+}
+export interface RawEntity {
+  Name: string;
+  FoundIn?: FoundInEntityOrSectionIdentifiersEntity[] | null;
+  MonthsExperience?: MonthsExperience | null;
+  LastUsed?: LastUsed | null;
+}
+export interface FoundInEntityOrSectionIdentifiersEntity {
+  SectionType: string;
+  Id?: string | null;
+}
+export interface MonthsExperience {
+  Value: number;
+}
+export interface LastUsed {
+  Value: string;
+}
+export interface NormalizedEntity {
+  Name: string;
+  Id: string;
+  Type: string;
+  FoundIn?: FoundInEntityOrSectionIdentifiersEntity[] | null;
+  MonthsExperience?: MonthsExperience1 | null;
+  LastUsed?: LastUsed1 | null;
+  RawSkills?: string[] | null;
+}
+export interface MonthsExperience1 {
+  Value: number;
+}
+export interface LastUsed1 {
+  Value: string;
+}
+export interface RelatedProfessionClassesEntity {
+  Name: string;
+  Id: string;
+  Percent: number;
+  Groups?: GroupsEntity[] | null;
+}
+export interface GroupsEntity {
+  Name: string;
+  Id: string;
+  Percent: number;
+  NormalizedSkills?: string[] | null;
+}
+export interface CertificationsEntity {
+  Name: string;
+  MatchedFromList: boolean;
+  IsVariation: boolean;
+}
+export interface LanguageCompetenciesEntity {
+  Language: string;
+  LanguageCode: string;
+  FoundInContext: string;
+}
+export interface ReferencesEntity {
+  ReferenceName: ReferenceName;
+  Title: string;
+  Company: string;
+  Location: Location;
+  Telephones?: SchoolNameOrTelephonesEntity[] | null;
+}
+export interface ReferenceName {
+  FormattedName?: string | null;
+  GivenName?: string | null;
+  MiddleName?: string | null;
+  FamilyName?: string | null;
+}
+export interface Location {
+  CountryCode: string;
+  StreetAddressLines?: string[] | null;
+}
+export interface ResumeMetadata {
+  FoundSections?: FoundSectionsEntity[] | null;
+  ResumeQuality?: ResumeQualityEntity[] | null;
+  ReservedData: ReservedData;
+  PlainText: string;
+  DocumentLanguage: string;
+  DocumentCulture: string;
+  ParserSettings: string;
+  DocumentLastModified: string;
+}
+export interface FoundSectionsEntity {
+  FirstLineNumber: number;
+  LastLineNumber: number;
+  SectionType: string;
+  HeaderTextFound: string;
+}
+export interface ResumeQualityEntity {
+  Level: string;
+  Findings?: FindingsEntity[] | null;
+}
+export interface FindingsEntity {
+  QualityCode: string;
+  SectionIdentifiers?: FoundInEntityOrSectionIdentifiersEntity[] | null;
+  Message: string;
+}
+export interface ReservedData {
+  Phones?: string[] | null;
+  Names?: string[] | null;
+  EmailAddresses?: string[] | null;
+  Urls?: string[] | null;
+}
+export interface RedactedResumeData {
+  ContactInformation: ReferenceNameOrContactInformation;
+  ProfessionalSummary: string;
+  Education: Education;
+  EmploymentHistory: EmploymentHistory;
+  Skills: Skills;
+  Certifications?: CertificationsEntity[] | null;
+  LanguageCompetencies?: LanguageCompetenciesEntity[] | null;
+  QualificationsSummary: string;
+  ResumeMetadata: ResumeMetadata1;
+}
+export interface ReferenceNameOrContactInformation {}
+export interface ResumeMetadata1 {
+  FoundSections?: FoundSectionsEntity[] | null;
+  ResumeQuality?: ResumeQualityEntity[] | null;
+  PlainText: string;
+  DocumentLanguage: string;
+  DocumentCulture: string;
+  ParserSettings: string;
+  DocumentLastModified: string;
+}
+export interface ConversionMetadata {
+  DetectedType: string;
+  SuggestedFileExtension: string;
+  OutputValidityCode: string;
+  ElapsedMilliseconds: number;
+  DocumentHash: string;
+}
+export interface ParsingMetadata {
+  ElapsedMilliseconds: number;
+  TimedOut: boolean;
+}
+
+export interface ParsedResume {
+  email: string;
+  github?: string;
+  linkedin?: string;
+  portfolio?: string;
+  totalWorkExperience: number;
+  workExperiences: WorkExperience[];
+  skills: string[];
+}
+
+export interface WorkExperience {
+  id: string;
+  startDate: string;
+  endDate: string;
+  title: string;
+  company: string;
+  description: string;
+}

--- a/src/update_airtable.ts
+++ b/src/update_airtable.ts
@@ -1,20 +1,57 @@
+import fs from "fs";
+import path, { dirname } from "path";
 import dotenv from "dotenv";
 import Airtable from "airtable";
+import { fileURLToPath } from "url";
+import { ParsedResume } from "./resume_parser/resumeType";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 dotenv.config();
 
+// Personal Access Token
 const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
-
-const RECUITMENT_POC_BASE_ID = "appAzPLABIFEnKEaq";
-const JOB_APPLICANTS_TABLE_ID = "tblPkxGkE589uoHUy";
+const RECUITMENT_POC_BASE_ID = "appCtMM5bG3zNPKG0";
+const JOB_APPLICANTS_TABLE_ID = "tbl4tUbCI0OkJEIKV";
 
 type updateAirtableRecordParams = {
   email: string;
-  columnName: string;
-  columnValue: string;
+  fields: Partial<Record<string, any>>;
   tableId: string;
 };
+
+const createFields = async (fields: Record<string, string>) => {
+  const keys = Object.keys(fields);
+  keys.forEach(async (key: string) => {
+    const type = fields[key];
+    console.log("New field: " + key + " type: " + type);
+    const req = {
+      description: "",
+      name: key,
+      type,
+    };
+    if (type === "number") {
+      req["options"] = {
+        precision: 1,
+      };
+    }
+    const r = await fetch(
+      `https://api.airtable.com/v0/meta/bases/${RECUITMENT_POC_BASE_ID}/tables/${JOB_APPLICANTS_TABLE_ID}/fields`,
+      {
+        headers: {
+          Authorization: `Bearer ${AIRTABLE_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        method: "POST",
+        body: JSON.stringify(req),
+      },
+    );
+    console.log(await r.json());
+  });
+};
 const updateAirtableRecord = async (params: updateAirtableRecordParams) => {
-  const { email, columnName, columnValue, tableId } = params;
+  const { email, fields, tableId } = params;
 
   const base = new Airtable({ apiKey: AIRTABLE_API_KEY }).base(
     RECUITMENT_POC_BASE_ID,
@@ -25,17 +62,15 @@ const updateAirtableRecord = async (params: updateAirtableRecordParams) => {
   const records = await base(tableId)
     .select({ filterByFormula: `{Email} = "${email}"`, maxRecords: 1 })
     .firstPage();
-
+  base(tableId);
   if (records && records.length > 0) {
     const recordId = records[0].getId();
-
+    console.log(recordId, fields);
     // Now use the retrieved ID to update the record.
-    await base(tableId).update([
+    base(tableId).update([
       {
         id: recordId,
-        fields: {
-          [columnName]: columnValue,
-        },
+        fields,
       },
     ]);
 
@@ -46,30 +81,33 @@ const updateAirtableRecord = async (params: updateAirtableRecordParams) => {
 };
 
 const main = async () => {
-  try {
-    const workExperiences = [
-      {
-        "Company Name": "Google",
-        Industry: "Technology",
-        "Job Title": "Software Engineer",
-        "Years of Experience": 2,
-      },
-      {
-        "Company Name": "Facebook",
-        Industry: "Technology",
-        "Job Title": "Senior Software Engineer",
-        "Years of Experience": 3,
-      },
-    ];
+  // read the json file from the out folder
+  const resumesBuffer = fs.readFileSync(
+    path.join(`${__dirname}/../out/parsed_resumes.json`),
+  );
 
+  const resumes = JSON.parse(resumesBuffer.toString()) as ParsedResume[];
+
+  // create fields (required only once)
+  // const fields = {
+  //   Portfolio: "url",
+  //   "Total Work Experience(year)": "number",
+  //   "Work Experiences": "multilineText",
+  //   Skills: "multilineText",
+  // };
+  // await createFields(fields);
+  for (const resume of resumes) {
+    const email = resume.email;
     await updateAirtableRecord({
-      email: "test@gmail.com",
-      columnName: "Work Experiences",
-      columnValue: JSON.stringify(workExperiences, null, 2),
+      email,
+      fields: {
+        Portfolio: resume.portfolio,
+        "Years of Experience": Math.round(resume.totalWorkExperience / 12),
+        "Work Experiences": JSON.stringify(resume.workExperiences, null, 2),
+        Skills: resume.skills.join(", "),
+      },
       tableId: JOB_APPLICANTS_TABLE_ID,
     });
-  } catch (error) {
-    console.log("error calling airtable: ", error);
   }
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "module": "ESNext",
     "noImplicitAny": false,
     "skipLibCheck": true,
-    "target": "ES2020",
+    "target": "ESNext",
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
- Parse resume using Sovren
- Extract Work experiences and skills
- Insert them to a target Airtable

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding functionality to parse resumes and update an Airtable record with the parsed data. 

### Detailed summary
- Added `parse_resume.ts` file to parse resumes using Sovren API.
- Added `index.ts` file to load resumes from a folder and parse them.
- Added `update_airtable.ts` file to update Airtable record with parsed resume data.
- Created `resumeType.ts` file to define the resume data types.
- Added necessary imports and configurations.
- Created functions to handle parsing and updating Airtable.
- Updated `.gitignore` to include `resume/` and `out/` directories.
- Updated `tsconfig.json` to set the target to "ESNext".
- Added necessary dependencies (`fs`, `path`, `dotenv`, `url`, `fetch`).
- Created `parsed_resumes.json` file to store parsed resume data.

> The following files were skipped due to too many changes: `src/resume_parser/resumeType.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->